### PR TITLE
set tx_assessment_type to security if user is admin

### DIFF
--- a/src/handlers/GetAssessmentData/handleGetAssessmentData.ts
+++ b/src/handlers/GetAssessmentData/handleGetAssessmentData.ts
@@ -1,4 +1,4 @@
-import { handleMissingParameters } from '..';
+import { showQuickReplies } from '..';
 import { IDetectIntentResponseData, IGetAssessmentDataParameters } from '../../interfaces';
 import SlackService from '../../services/SlackService';
 import { handleGetEntityInfo } from '../GetEntityInfo/handleGetEntityInfo';
@@ -11,10 +11,7 @@ export async function handleGetAssessmentData(
 	slackService: SlackService
 ): Promise<void> {
 	if (!response.allRequiredParamsPresent) {
-		const showingQuickReplies = await handleMissingParameters(response, slackService);
-		if (showingQuickReplies) {
-			return;
-		}
+		return showQuickReplies(response, slackService);
 	}
 
 	const parameters = response.parameters as IGetAssessmentDataParameters;

--- a/src/handlers/GetEntityInfo/handleGetEntityInfo.ts
+++ b/src/handlers/GetEntityInfo/handleGetEntityInfo.ts
@@ -1,5 +1,5 @@
 import { Button } from '@slack/web-api';
-import { handleMissingParameters } from '..';
+import { showQuickReplies } from '..';
 import { ICompany, IDetectIntentResponseData, IGetEntityInfoParameters, IType } from '../../interfaces';
 import DataService from '../../services/DataService';
 import SlackService from '../../services/SlackService';
@@ -12,10 +12,7 @@ export async function handleGetEntityInfo(
 	slackService: SlackService
 ): Promise<void> {
 	if (!response.allRequiredParamsPresent) {
-		const showingQuickReplies = await handleMissingParameters(response, slackService);
-		if (showingQuickReplies) {
-			return;
-		}
+		return showQuickReplies(response, slackService);
 	}
 
 	const parameters = response.parameters as IGetEntityInfoParameters;

--- a/src/handlers/GetRiskChart/handleGetRiskChart.ts
+++ b/src/handlers/GetRiskChart/handleGetRiskChart.ts
@@ -11,20 +11,17 @@ import { createScatterChart } from '../../slack/charts/scatterChart';
 import { createAssessmentDataBlock } from '../../slack/blocks/createAssessmentDataBlock';
 import DataService from '../../services/DataService';
 import { AxiosError } from 'axios';
-import { handleMissingParameters } from '..';
 import RiskTowerService from '../../services/RiskTowerService';
 import { Button } from '@slack/web-api';
 import { createSwitchAsessmentButtons } from '../../slack/blocks/createSwitchAsessmentButtons';
+import { showQuickReplies } from '..';
 
 export async function handleGetRiskChart(
 	response: IDetectIntentResponseData,
 	slackService: SlackService
 ): Promise<void> {
 	if (!response.allRequiredParamsPresent) {
-		const showingQuickReplies = await handleMissingParameters(response, slackService);
-		if (showingQuickReplies) {
-			return;
-		}
+		return showQuickReplies(response, slackService);
 	}
 
 	const parameters = response.parameters as IGetRiskChartParameters;

--- a/src/handlers/GetRiskEpics/handleGetRiskEpics.ts
+++ b/src/handlers/GetRiskEpics/handleGetRiskEpics.ts
@@ -1,5 +1,5 @@
 import { Button } from '@slack/web-api';
-import { handleMissingParameters } from '..';
+import { showQuickReplies } from '..';
 import { ICompany, IDetectIntentResponseData, IGetRiskEpicsParameters, IJiraTicket, IType } from '../../interfaces';
 import DataService from '../../services/DataService';
 import SlackService from '../../services/SlackService';
@@ -11,10 +11,7 @@ export async function handleGetRiskEpics(
 	slackService: SlackService
 ): Promise<void> {
 	if (!response.allRequiredParamsPresent) {
-		const showingQuickReplies = await handleMissingParameters(response, slackService);
-		if (showingQuickReplies) {
-			return;
-		}
+		return showQuickReplies(response, slackService);
 	}
 
 	const parameters = response.parameters as IGetRiskEpicsParameters;

--- a/src/handlers/GetRiskRatings/handleGetRiskRatings.ts
+++ b/src/handlers/GetRiskRatings/handleGetRiskRatings.ts
@@ -1,5 +1,5 @@
 import { Button } from '@slack/web-api';
-import { handleMissingParameters } from '..';
+import { showQuickReplies } from '..';
 import { ICompany, IDetectIntentResponseData, IGetRiskRatingsParameters, IType, RiskArea } from '../../interfaces';
 import DataService from '../../services/DataService';
 import SlackService from '../../services/SlackService';
@@ -11,10 +11,7 @@ export async function handleGetRiskRatings(
 	slackService: SlackService
 ): Promise<void> {
 	if (!response.allRequiredParamsPresent) {
-		const showingQuickReplies = await handleMissingParameters(response, slackService);
-		if (showingQuickReplies) {
-			return;
-		}
+		return showQuickReplies(response, slackService);
 	}
 
 	const parameters = response.parameters as IGetRiskRatingsParameters;

--- a/src/handlers/GetRisks/handleGetRisks.ts
+++ b/src/handlers/GetRisks/handleGetRisks.ts
@@ -7,7 +7,7 @@ import { createScatterChart } from '../../slack/charts/scatterChart';
 import { createAssessmentDataBlock } from '../../slack/blocks/createAssessmentDataBlock';
 import { createRisksBlock } from '../../slack/blocks/createRisksBlock';
 import { createMessageBlock } from '../../slack/blocks/createMessageBlock';
-import { handleMissingParameters } from '..';
+import { showQuickReplies } from '..';
 import { createSwitchAsessmentButtons } from '../../slack/blocks/createSwitchAsessmentButtons';
 import { Button } from '@slack/web-api';
 
@@ -17,10 +17,7 @@ export async function handleGetRisks(response: IDetectIntentResponseData, slackS
 	}
 
 	if (!response.allRequiredParamsPresent) {
-		const showingQuickReplies = await handleMissingParameters(response, slackService);
-		if (showingQuickReplies) {
-			return;
-		}
+		return showQuickReplies(response, slackService);
 	}
 
 	const parameters = response.parameters as IGetRisksParameters;

--- a/src/handlers/GetTopFindings/handleGetTopFindings.ts
+++ b/src/handlers/GetTopFindings/handleGetTopFindings.ts
@@ -1,4 +1,4 @@
-import { handleMissingParameters } from '..';
+import { showQuickReplies } from '..';
 import { IDetectIntentResponseData, IGetTopFindingsParameters } from '../../interfaces';
 import DataService from '../../services/DataService';
 import SlackService from '../../services/SlackService';
@@ -9,10 +9,7 @@ export async function handleGetTopFindings(
 	slackService: SlackService
 ): Promise<void> {
 	if (!response.allRequiredParamsPresent) {
-		const showingQuickReplies = await handleMissingParameters(response, slackService);
-		if (showingQuickReplies) {
-			return;
-		}
+		return showQuickReplies(response, slackService);
 	}
 
 	const parameters = response.parameters as IGetTopFindingsParameters;

--- a/src/handlers/GetTopMeasures/handleGetTopMeasures.ts
+++ b/src/handlers/GetTopMeasures/handleGetTopMeasures.ts
@@ -2,17 +2,14 @@ import { createTopMeasuresBlock } from '../../slack/blocks/createTopMeasuresBloc
 import { IDetectIntentResponseData, IGetTopMeasuresParameters } from '../../interfaces';
 import SlackService from '../../services/SlackService';
 import DataService from '../../services/DataService';
-import { handleMissingParameters } from '..';
+import { showQuickReplies } from '..';
 
 export async function handleGetTopMeasures(
 	response: IDetectIntentResponseData,
 	slackService: SlackService
 ): Promise<void> {
 	if (!response.allRequiredParamsPresent) {
-		const showingQuickReplies = await handleMissingParameters(response, slackService);
-		if (showingQuickReplies) {
-			return;
-		}
+		return showQuickReplies(response, slackService);
 	}
 
 	const parameters = response.parameters as IGetTopMeasuresParameters;


### PR DESCRIPTION
if the user is an admin, answer the slot filling request without showing the message from dialogflow and call the handler function again with a fakeEvent containing "security" as text. This way the slotfilling is answerd without the user noticing it, and the handler runs again, with tx_assessment_type set to security.